### PR TITLE
Fix bugs in the orbital projection functions

### DIFF
--- a/horton/matrix/dense.py
+++ b/horton/matrix/dense.py
@@ -1331,26 +1331,33 @@ class DenseExpansion(Expansion):
                 out._array += factor*np.dot(self._coeffs*self.occupations, other._coeffs.T)
         return out
 
-    def assign_dot(self, other, tf2):
+    def assign_dot(self, left, right):
         '''Dot product of orbitals in a DenseExpansion and TwoIndex object
 
            **Arguments:**
 
-           other
-                An expansion object with input orbitals
-
-           tf2
-                A two-index object
+           left, right:
+                An expansion and a two-index object, or a two-index and an expansion
+                object.
 
            The transformed orbitals are stored in self.
         '''
-        check_type('other', other, DenseExpansion)
-        check_type('tf2', tf2, DenseTwoIndex)
-        if not (self.nbasis == other.nbasis):
-            raise TypeError('Both expansions must have the same number of basis functions.')
-        if not (tf2.shape[0] == other.nfn and tf2.shape[1] == self.nfn):
-            raise TypeError('The shape of the two-index object is incompatible with that of the expansions.')
-        self._coeffs[:] = np.dot(other.coeffs, tf2._array)
+        if isinstance(left, DenseExpansion):
+            check_type('left', left, DenseExpansion)
+            check_type('right', right, DenseTwoIndex)
+            if not (self.nbasis == left.nbasis):
+                raise TypeError('Both expansions must have the same number of basis functions.')
+            if not (right.shape[0] == left.nfn and right.shape[1] == self.nfn):
+                raise TypeError('The shape of the two-index object is incompatible with that of the expansions.')
+            self._coeffs[:] = np.dot(left.coeffs, right._array)
+        elif isinstance(right, DenseExpansion):
+            check_type('left', left, DenseTwoIndex)
+            check_type('right', right, DenseExpansion)
+            if not (self.nfn == right.nfn):
+                raise TypeError('Both expansions must have the same number of orbitals.')
+            if not (left.shape[1] == right.nbasis and left.shape[1] == self.nbasis):
+                raise TypeError('The shape of the two-index object is incompatible with that of the expansions.')
+            self._coeffs[:] = np.dot(left._array, right.coeffs)
 
     def assign_occupations(self, occupation):
         '''Assign orbital occupations

--- a/horton/matrix/test/test_dense.py
+++ b/horton/matrix/test/test_dense.py
@@ -770,7 +770,7 @@ def test_expansion_to_dm3():
     assert not dm.is_symmetric()
 
 
-def test_expansion_assign_dot():
+def test_expansion_assign_dot1():
     lf = DenseLinalgFactory(2)
     exp0 = lf.create_expansion()
     exp1 = lf.create_expansion()
@@ -779,6 +779,17 @@ def test_expansion_assign_dot():
     tf2.randomize()
     exp1.assign_dot(exp0, tf2)
     assert np.allclose(exp1.coeffs, np.dot(exp0.coeffs, tf2._array))
+
+
+def test_expansion_assign_dot2():
+    lf = DenseLinalgFactory(2)
+    exp0 = lf.create_expansion()
+    exp1 = lf.create_expansion()
+    tf2 = lf.create_two_index()
+    exp0.randomize()
+    tf2.randomize()
+    exp1.assign_dot(tf2, exp0)
+    assert np.allclose(exp1.coeffs, np.dot(tf2._array, exp0.coeffs))
 
 
 def test_expansion_assign_occupations():

--- a/horton/meanfield/test/test_project.py
+++ b/horton/meanfield/test/test_project.py
@@ -158,6 +158,9 @@ def get_basis_pair_geometry():
     lf = DenseLinalgFactory(obasis0.nbasis)
     exp0 = lf.create_expansion()
 
+    # Occupy all orbitals such that orthogonality is well tested
+    exp0.occupations[:] = 1.0
+
     # core-hamiltonian guess
     olp = obasis0.compute_overlap(lf)
     kin = obasis0.compute_kinetic(lf)
@@ -169,7 +172,8 @@ def get_basis_pair_geometry():
     exp0.check_orthonormality(obasis0.compute_overlap(lf))
 
     # Change geometry
-    mol.coordinates[1,2] += 0.1
+    mol.coordinates[1,2] += 0.5
+    mol.coordinates[0,1] -= 1.5
     obasis1 = get_gobasis(mol.coordinates, mol.numbers, 'sto-3g')
     exp1 = lf.create_expansion()
 
@@ -186,7 +190,6 @@ def test_project_msg_geometry():
     assert (exp1.energies == 0.0).all()
     assert (exp1.occupations == exp0.occupations).all()
     assert abs(exp1.coeffs[:,:5] - exp0.coeffs[:,:5]).max() > 1e-3 # something should change
-    assert (exp1.coeffs[:,5:] == 0.0).all()
 
     # Check orthonormality
     exp1.check_orthonormality(obasis1.compute_overlap(lf))


### PR DESCRIPTION
Some bugs went unnoticed because one of the tests was not properly
checking the orthonormality of the orbitals. These tests are now fixed.

After fixing the tests, some of them were failing, which revealed two
bugs in horton/meanfield/project.py. In both cases, the orbitals were no
longer orthonormal after projection. Both bugs are fixed.

THIS IS FOR TESTING QA ONLY